### PR TITLE
Batch operations and lowercase keys and group config

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,14 +10,17 @@ import { getGender } from '../genderize';
 import { requireKey } from '../middlewares';
 import { buildRecord, sanitizeName } from '../utils';
 import express from 'express';
+import { getConfigForGroup, setConfigForGroup } from '../config';
 
 const router = express.Router();
 
 router.use(requireKey);
 
 router.get('/:chatId/list', async (req, res) => {
-  const birthdays = await getRecordsByChatId(parseInt(req.params.chatId));
-  res.json({ birthdays });
+  const chatId = parseInt(req.params.chatId);
+  const birthdays = await getRecordsByChatId(chatId);
+  const config = await getConfigForGroup(chatId);
+  res.json({ birthdays, config });
 });
 
 router.post('/:chatId/import', async (req, res) => {
@@ -78,6 +81,13 @@ router.post('/:chatId/batch', async (req, res) => {
           name: record.name,
           chatId: parseInt(req.params.chatId),
         });
+      } catch (e) {
+        console.error(e);
+        continue;
+      }
+    } else if (record.op === 'config') {
+      try {
+        await setConfigForGroup(parseInt(req.params.chatId), record.value);
       } catch (e) {
         console.error(e);
         continue;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,12 +21,10 @@ export const allCommands = [
   },
   {
     command: 'add',
-    description:
-      'Adiciona novo aniversariante. Limitado a Admins do grupo para evitar abusos de confiança.',
+    description: 'Adiciona novo aniversariante.',
   },
   {
     command: 'remove',
-    description:
-      'Remove um aniversariante. Limitado a Admins do grupo para evitar abusos de confiança.',
+    description: 'Remove um aniversariante.',
   },
 ];

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -29,9 +29,13 @@ export const removeCommand = async (ctx: CommandContext<MyContext>) => {
 
   // limits add commands to group admins
   try {
-    const chatMember = await ctx.api.getChatMember(intChatId, ctx.from!.id);
-    if (!['administrator', 'creator'].includes(chatMember.status)) {
-      return ctx.reply(t('errors.notAdmin'));
+    const groupConfig = await getConfigForGroup(intChatId);
+
+    if (groupConfig && groupConfig.restrictedToAdmins) {
+      const chatMember = await ctx.api.getChatMember(intChatId, ctx.from!.id);
+      if (!['administrator', 'creator'].includes(chatMember.status)) {
+        return ctx.reply(t('errors.notAdmin'));
+      }
     }
   } catch (error) {
     return ctx.reply(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,30 @@
+import CyclicDb from '@cyclic.sh/dynamodb';
+
+const db = CyclicDb(process.env.CYCLIC_DB);
+const configKey = process.env.NODE_ENV === 'test' ? 'config:test' : 'config';
+const config = db.collection(configKey);
+
+type ChatConfig = { restrictedToAdmins: boolean };
+
+export const getConfigForGroup = async (
+  chatId: number
+): Promise<ChatConfig | null> => {
+  try {
+    const record = await config.get(`${chatId}`);
+    return record ? record.props.value : null;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
+
+export const setConfigForGroup = async (
+  chatId: number,
+  newConfig: ChatConfig
+) => {
+  try {
+    return await config.set(`${chatId}`, { value: newConfig });
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/dynamodb.test.ts
+++ b/src/dynamodb.test.ts
@@ -139,4 +139,36 @@ describe('DynamoDB tests', () => {
       await getRecordsByDayAndMonth({ day: record.day, month: record.month })
     ).toEqual([record]);
   });
+
+  it('upserts', async () => {
+    let record = {
+      name: 'Rui',
+      date: '1984-12-26',
+      month: 12,
+      day: 26,
+      gender,
+      chatId,
+    };
+
+    await addRecord(record);
+    await addRecord({ ...record, name: 'RUI' });
+    await addRecord({ ...record, name: 'rUi' });
+    expect((await getRecordsByChatId(chatId)).length).toEqual(1);
+  });
+
+  it('normalises keys to lowercase', async () => {
+    let record = {
+      name: 'RUI',
+      date: '1984-12-26',
+      month: 12,
+      day: 26,
+      gender,
+      chatId,
+    };
+
+    await addRecord(record);
+    expect((await getRecordsByChatId(chatId)).length).toEqual(1);
+    await removeRecord({ name: 'rUi', chatId });
+    expect((await getRecordsByChatId(chatId)).length).toEqual(0);
+  });
 });

--- a/src/dynamodb.ts
+++ b/src/dynamodb.ts
@@ -9,13 +9,13 @@ type DBKeyArgs = Pick<BirthdayRecord, 'name' | 'chatId'>;
 function buildRecordKey(record: DBKeyArgs): string {
   const { chatId, name } = record;
 
-  return `${chatId}:${name}`;
+  return `${chatId}:${name.toLowerCase()}`;
 }
 
 export async function addRecord({ ...params }: BirthdayRecord) {
   const key = buildRecordKey(params);
 
-  console.log(`Adding ${key}: ${JSON.stringify(params)}`);
+  console.info(`Adding ${key}: ${JSON.stringify(params)}`);
 
   const record = await birthdays.set(
     key,
@@ -35,6 +35,7 @@ export async function removeRecord({
   const record = await birthdays.get(key);
 
   if (record) {
+    console.info(`Removing ${key}: ${JSON.stringify(params)}`);
     await record.delete();
     return parseRecord(record);
   } else {


### PR DESCRIPTION
3 features in 1:
 - API for batch add/remove operations
 - Lowercases names for keys. This might make some people unremovable and require clear/re-import of all data, sorry!
 - Group config. Enables restricting add/remove commands for admins. Off by default (everyone can add/remove) - this is done through the batch command and shows on group list API endpoint