### PR TITLE
Makes the trigger notification time configurable

### DIFF
--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -10,6 +10,12 @@
     },
     "add": {
       "success": "Aniversariante adicionado: {{name}} — {{date}}."
+    },
+    "config": {
+      "notfound": "Configuracao invalida.",
+      "error": "Erro ao obter a configuracao para o grupo.",
+      "saved": "Configuracao actualizada com sucesso",
+      "errorParsingHour": "Hora invalida - deve ser um numero 0-23."
     }
   },
   "errors": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -9,6 +9,7 @@ import {
   removeCommand,
   helpCommand,
   magicCommand,
+  configCommand,
   allCommands,
 } from './commands';
 import { addRecord, getRecordsByDayAndMonth } from './dynamodb';
@@ -29,6 +30,7 @@ const bot = new Bot<MyContext>(process.env.TELEGRAM_TOKEN);
 bot.command(['aniversarios', 'birthdays'], withChatId, birthdaysCommand);
 bot.command(['list', 'idades'], withChatId, listCommand);
 bot.command(['proximo', 'next'], withChatId, nextCommand);
+bot.command(['config'], withChatId, configCommand);
 bot.command(['ajuda', 'help'], helpCommand);
 bot.command(['debug'], async (ctx) => {
   console.log(JSON.stringify(ctx, null, 2));
@@ -36,6 +38,7 @@ bot.command(['debug'], async (ctx) => {
 
 // /add name, date
 // /add name, date, chatId (for private chats)
+// TODO should these not have withChatID too? not sure - check
 bot.command('add', addCommand);
 bot.command('remove', removeCommand);
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,63 @@
+import { CommandContext } from 'grammy';
+import { MyContext } from '../bot';
+import { removeRecord } from '../dynamodb';
+import { isGroup, sanitizeName } from '../utils';
+import { t } from 'i18next';
+import { getConfigForGroup, setConfigForGroup } from '../config';
+import { ChatCompletion } from 'openai/resources';
+import type { ChatConfig } from '../config';
+
+// dissalowing resetting the masterId
+const ALLOWED_CONFIG: Partial<Record<keyof ChatConfig, keyof ChatConfig>> = {
+  restrictedToAdmins: 'restrictedToAdmins',
+  notificationHour: 'notificationHour',
+};
+
+export const configCommand = async (ctx: CommandContext<MyContext>) => {
+  // restric to admins
+  const chatMember = await ctx.api.getChatMember(ctx.chatId, ctx.from!.id);
+  if (!['administrator', 'creator'].includes(chatMember.status)) {
+    return ctx.reply(t('errors.notAdmin'));
+  }
+
+  const payload = ctx.match.split(',').map((s) => s.trim()) || [];
+  const command = payload[0];
+  const arg = payload[1];
+
+  if (!command || parseInt(command) === ctx.chatId) {
+    // getting the config
+    try {
+      const groupConfig = await getConfigForGroup(ctx.chatId);
+      return ctx.reply(JSON.stringify(groupConfig));
+    } catch (error) {
+      return ctx.reply(
+        t('commands.config.error', { error: (error as Error).message })
+      );
+    }
+  }
+
+  console.log(ALLOWED_CONFIG, command, ctx.match);
+
+  if (!Object.keys(ALLOWED_CONFIG).includes(command)) {
+    return ctx.reply(t('commands.config.notfound'));
+  }
+
+  if (command === ALLOWED_CONFIG.restrictedToAdmins) {
+    let boolArg = Boolean(arg === 'false' ? false : arg);
+    await setConfigForGroup(ctx.chatId, { restrictedToAdmins: boolArg });
+    return ctx.reply(t('commands.config.saved'));
+  } else if (command === ALLOWED_CONFIG.notificationHour) {
+    let numArg = parseInt(arg);
+
+    if (isNaN(numArg) || numArg < 0 || numArg > 23) {
+      return ctx.reply(
+        t('commands.config.errorParsingHour', {
+          error: 'Could not parse the provided hour',
+        })
+      );
+    }
+
+    await setConfigForGroup(ctx.chatId, { notificationHour: numArg });
+    return ctx.reply(t('commands.config.saved'));
+  }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,6 +5,7 @@ export * from './add';
 export * from './remove';
 export * from './help';
 export * from './magic';
+export * from './config';
 
 export const allCommands = [
   {
@@ -28,6 +29,10 @@ export const allCommands = [
   {
     command: 'remove',
     description: 'Remove um aniversariante.',
+  },
+  {
+    command: 'config',
+    description: 'Altera configuracoes do grupo.',
   },
   {
     command: 'birthdaybot',

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,10 @@ const db = CyclicDb(process.env.CYCLIC_DB);
 const configKey = process.env.NODE_ENV === 'test' ? 'config:test' : 'config';
 const config = db.collection(configKey);
 
-type ChatConfig = {
+export type ChatConfig = {
   restrictedToAdmins: boolean;
   masterId: number;
+  notificationHour: number;
 };
 
 export const getConfigForGroup = async (

--- a/src/middlewares/withChatId.ts
+++ b/src/middlewares/withChatId.ts
@@ -9,11 +9,18 @@ export const withChatId: MiddlewareFn<MyContext> = async (ctx, next) => {
     chatId = ctx.chat.id;
   } else {
     // on a private 1:1, need to supply chatId on the message
-    chatId = parseInt(typeof ctx.match === 'string' ? ctx.match : '');
+    const payload = typeof ctx.match === 'string' ? ctx.match : null;
 
-    if (!ctx.match) {
+    if (!payload) {
       return ctx.reply(`Need a Chat ID on a private chat.`);
     }
+
+    // gets the last comma seperated token.
+    // some commands take multiple tokens with a chatId at the end, some others
+    // take no payload, only the chatId (on a private bot chat)
+    const tokens = payload.split(',').map((s) => s.trim()) || [];
+    chatId = parseInt(tokens.pop() || ''); // empty string and undefined will make parseInt return NaN
+
     if (isNaN(chatId)) {
       return ctx.reply(`Invalid Chat ID provided, got '${ctx.match}'.`);
     }


### PR DESCRIPTION
Couple of changes:
 - adds a command to get/set group configuration. restricted to getting and setting notification hour and whether non admins can add and remove birthdays
 - makes the trigger respect this config if set
 - also added support for a env var to globally control the default hour notifications are triggered from
 - THE NOTIFICATION HOUR IS NOW UTC